### PR TITLE
Remove empty format precision specifier

### DIFF
--- a/client/src/render.rs
+++ b/client/src/render.rs
@@ -333,7 +333,7 @@ fn render_debug_ui(
 ) {
     let x = game_state.camera.logical_screen_size.x - 48.0;
     let lines = [
-        ("FPS:", &format!("{:.}", metrics.fps_stats.fps)),
+        ("FPS:", &format!("{}", metrics.fps_stats.fps)),
         ("p50:", &format!("{:.1}ms", metrics.fps_stats.median_ms)),
         ("p100:", &format!("{:.1} ms", metrics.fps_stats.max_ms)),
         ("ping:", &format!("{:.1} ms", game_state.ping_rtt * 1000.0)),


### PR DESCRIPTION
A format precision specifier consisting of a dot and no number actually does nothing and has no specified meaning. Currently this is silently ignored, but it may turn into a warning or error.

See rust-lang/rust#131159 and rust-lang/rust#136638

Please leave a comment there if you have any opinion about this. If you remember why this was written this way that could help improve the diagnostics rustc gives.